### PR TITLE
方便使用者对自身环境适配

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -2,14 +2,15 @@ apply plugin: 'com.android.application'
 apply plugin: 'android-apt'
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion "25"
+    compileSdkVersion setup.compileSdk
+    buildToolsVersion setup.buildTools
+
     defaultConfig {
         applicationId "zlc.season.rxdownloadproject"
-        minSdkVersion 11
-        targetSdkVersion 25
-        versionCode 1
-        versionName "1.0"
+        minSdkVersion setup.minSdk
+        targetSdkVersion setup.targetSdk
+        versionCode setup.vcode
+        versionName setup.vname
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
     }
     buildTypes {
@@ -25,10 +26,12 @@ dependencies {
     androidTestCompile('com.android.support.test.espresso:espresso-core:2.2.2', {
         exclude group: 'com.android.support', module: 'support-annotations'
     })
-    compile 'com.android.support:appcompat-v7:25.0.1'
-    compile 'com.android.support:design:25.0.1'
-    compile 'com.jakewharton:butterknife:8.4.0'
-    apt 'com.jakewharton:butterknife-compiler:8.4.0'
+    compile "com.android.support:appcompat-v7:${versions.libSupport}"
+    compile "com.android.support:design:${versions.libSupport}"
+    //
+    compile "com.jakewharton:butterknife:${versions.libButterKnife}"
+    apt "com.jakewharton:butterknife-compiler:${versions.libButterKnife}"
+    //
     compile 'com.squareup.picasso:picasso:2.5.2'
     compile 'zlc.season:practicalrecyclerview:1.0.8'
     compile 'com.tbruyelle.rxpermissions2:rxpermissions:0.8.2@aar'

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,18 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
-
 buildscript {
+    ext {
+        setup = [compileSdk: 25,
+                 buildTools: "25.0.2",
+                 minSdk    : 11,
+                 targetSdk : 25,
+                 vcode     : 2,
+                 vname     : "1.0.1"]
+        versions = [libSupport    : "25.1.0",
+                    libButterKnife: "8.4.0",
+                    libRxJava     : "2.0.1",
+                    libRetrofit   : "2.1.0",
+                    libOkhttp3    : "3.4.1"]
+    }
     repositories {
         jcenter()
     }

--- a/rxdownload2/build.gradle
+++ b/rxdownload2/build.gradle
@@ -1,14 +1,14 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion "25"
+    compileSdkVersion setup.compileSdk
+    buildToolsVersion setup.buildTools
 
     defaultConfig {
-        minSdkVersion 11
-        targetSdkVersion 25
-        versionCode 1
-        versionName "1.0"
+        minSdkVersion setup.minSdk
+        targetSdkVersion setup.targetSdk
+        versionCode setup.vcode
+        versionName setup.vname
 
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
 
@@ -26,18 +26,18 @@ dependencies {
     androidTestCompile('com.android.support.test.espresso:espresso-core:2.2.2', {
         exclude group: 'com.android.support', module: 'support-annotations'
     })
-    compile 'com.android.support:appcompat-v7:25.0.1'
+    compile "com.android.support:appcompat-v7:${versions.libSupport}"
     testCompile 'junit:junit:4.12'
     //retrofit
-    compile 'com.squareup.retrofit2:retrofit:2.1.0'
-    compile 'com.squareup.retrofit2:converter-gson:2.1.0'
+    compile "com.squareup.retrofit2:retrofit:${versions.libRetrofit}"
+    compile "com.squareup.retrofit2:converter-gson:${versions.libRetrofit}"
     compile 'com.jakewharton.retrofit:retrofit2-rxjava2-adapter:1.0.0'
 
-    compile 'com.squareup.okhttp3:okhttp:3.4.1'
-    compile 'com.squareup.okhttp3:logging-interceptor:3.4.1'
+    compile "com.squareup.okhttp3:okhttp:${versions.libOkhttp3}"
+    compile "com.squareup.okhttp3:logging-interceptor:${versions.libOkhttp3}"
 
-    compile 'io.reactivex.rxjava2:rxjava:2.0.1'
-    compile 'io.reactivex.rxjava2:rxandroid:2.0.1'
+    compile "io.reactivex.rxjava2:rxjava:${versions.libRxJava}"
+    compile "io.reactivex.rxjava2:rxandroid:${versions.libRxJava}"
 }
 
 apply from: "bintray.gradle"


### PR DESCRIPTION
因为不可抗拒的历史原因，
不同开发者本地编译环境不同，
依赖版本不同，
所以对版本号进行了统一配置。