### PR TITLE
Extracted RxDownload Interface to support mocking

### DIFF
--- a/rxdownload3/src/main/java/zlc/season/rxdownload3/RxDownload.kt
+++ b/rxdownload3/src/main/java/zlc/season/rxdownload3/RxDownload.kt
@@ -9,98 +9,98 @@ import zlc.season.rxdownload3.extension.Extension
 import java.io.File
 
 
-object RxDownload {
+object RxDownload : RxDownloadI {
     private val downloadCore = DownloadCore()
 
-    fun isExists(url: String): Maybe<Boolean> {
+    override fun isExists(url: String): Maybe<Boolean> {
         return isExists(Mission(url))
     }
 
-    fun isExists(mission: Mission): Maybe<Boolean> {
+    override fun isExists(mission: Mission): Maybe<Boolean> {
         return downloadCore.isExists(mission)
     }
 
-    fun create(url: String): Flowable<Status> {
+    override fun create(url: String): Flowable<Status> {
         return create(Mission(url))
     }
 
-    fun create(mission: Mission): Flowable<Status> {
+    override fun create(mission: Mission): Flowable<Status> {
         return downloadCore.create(mission)
     }
 
-    fun update(newMission: Mission): Maybe<Any> {
+    override fun update(newMission: Mission): Maybe<Any> {
         return downloadCore.update(newMission)
     }
 
-    fun start(url: String): Maybe<Any> {
+    override fun start(url: String): Maybe<Any> {
         return start(Mission(url))
     }
 
-    fun start(mission: Mission): Maybe<Any> {
+    override fun start(mission: Mission): Maybe<Any> {
         return downloadCore.start(mission)
     }
 
-    fun stop(url: String): Maybe<Any> {
+    override fun stop(url: String): Maybe<Any> {
         return stop(Mission(url))
     }
 
-    fun stop(mission: Mission): Maybe<Any> {
+    override fun stop(mission: Mission): Maybe<Any> {
         return downloadCore.stop(mission)
     }
 
-    fun delete(url: String, deleteFile: Boolean = false): Maybe<Any> {
+    override fun delete(url: String, deleteFile: Boolean): Maybe<Any> {
         return delete(Mission(url), deleteFile)
     }
 
-    fun delete(mission: Mission, deleteFile: Boolean = false): Maybe<Any> {
+    override fun delete(mission: Mission, deleteFile: Boolean): Maybe<Any> {
         return downloadCore.delete(mission, deleteFile)
     }
 
-    fun clear(url: String): Maybe<Any> {
+    override fun clear(url: String): Maybe<Any> {
         return clear(Mission(url))
     }
 
-    fun clear(mission: Mission): Maybe<Any> {
+    override fun clear(mission: Mission): Maybe<Any> {
         return downloadCore.clear(mission)
     }
 
-    fun getAllMission(): Maybe<List<Mission>> {
+    override fun getAllMission(): Maybe<List<Mission>> {
         return downloadCore.getAllMission()
     }
 
-    fun createAll(missions: List<Mission>): Maybe<Any> {
+    override fun createAll(missions: List<Mission>): Maybe<Any> {
         return downloadCore.createAll(missions)
     }
 
-    fun startAll(): Maybe<Any> {
+    override fun startAll(): Maybe<Any> {
         return downloadCore.startAll()
     }
 
-    fun stopAll(): Maybe<Any> {
+    override fun stopAll(): Maybe<Any> {
         return downloadCore.stopAll()
     }
 
-    fun deleteAll(deleteFile: Boolean = false): Maybe<Any> {
+    override fun deleteAll(deleteFile: Boolean): Maybe<Any> {
         return downloadCore.deleteAll(deleteFile)
     }
 
-    fun clearAll(): Maybe<Any> {
+    override fun clearAll(): Maybe<Any> {
         return downloadCore.clearAll()
     }
 
-    fun file(url: String): Maybe<File> {
+    override fun file(url: String): Maybe<File> {
         return file(Mission(url))
     }
 
-    fun file(mission: Mission): Maybe<File> {
+    override fun file(mission: Mission): Maybe<File> {
         return downloadCore.file(mission)
     }
 
-    fun extension(url: String, type: Class<out Extension>): Maybe<Any> {
+    override fun extension(url: String, type: Class<out Extension>): Maybe<Any> {
         return extension(Mission(url), type)
     }
 
-    fun extension(mission: Mission, type: Class<out Extension>): Maybe<Any> {
+    override fun extension(mission: Mission, type: Class<out Extension>): Maybe<Any> {
         return downloadCore.extension(mission, type)
     }
 }

--- a/rxdownload3/src/main/java/zlc/season/rxdownload3/RxDownloadI.kt
+++ b/rxdownload3/src/main/java/zlc/season/rxdownload3/RxDownloadI.kt
@@ -1,0 +1,35 @@
+package zlc.season.rxdownload3
+
+import io.reactivex.Flowable
+import io.reactivex.Maybe
+import zlc.season.rxdownload3.core.Mission
+import zlc.season.rxdownload3.core.Status
+import zlc.season.rxdownload3.extension.Extension
+import java.io.File
+
+
+interface RxDownloadI {
+	fun isExists(url: String): Maybe<Boolean>
+	fun isExists(mission: Mission): Maybe<Boolean>
+	fun create(url: String): Flowable<Status>
+	fun create(mission: Mission): Flowable<Status>
+	fun update(newMission: Mission): Maybe<Any>
+	fun start(url: String): Maybe<Any>
+	fun start(mission: Mission): Maybe<Any>
+	fun stop(url: String): Maybe<Any>
+	fun stop(mission: Mission): Maybe<Any>
+	fun delete(url: String, deleteFile: Boolean = false): Maybe<Any>
+	fun delete(mission: Mission, deleteFile: Boolean = false): Maybe<Any>
+	fun clear(url: String): Maybe<Any>
+	fun clear(mission: Mission): Maybe<Any>
+	fun getAllMission(): Maybe<List<Mission>>
+	fun createAll(missions: List<Mission>): Maybe<Any>
+	fun startAll(): Maybe<Any>
+	fun stopAll(): Maybe<Any>
+	fun deleteAll(deleteFile: Boolean = false): Maybe<Any>
+	fun clearAll(): Maybe<Any>
+	fun file(url: String): Maybe<File>
+	fun file(mission: Mission): Maybe<File>
+	fun extension(url: String, type: Class<out Extension>): Maybe<Any>
+	fun extension(mission: Mission, type: Class<out Extension>): Maybe<Any>
+}


### PR DESCRIPTION
It is needed for unit tests. With `RxDownloadI`, it is possible to mock.