### PR TITLE
Made Range download size configurable. Closes #174

### DIFF
--- a/rxdownload3/src/main/java/zlc/season/rxdownload3/core/DownloadConfig.kt
+++ b/rxdownload3/src/main/java/zlc/season/rxdownload3/core/DownloadConfig.kt
@@ -2,7 +2,6 @@ package zlc.season.rxdownload3.core
 
 import android.annotation.SuppressLint
 import android.content.Context
-import android.os.Build
 import android.os.Environment.DIRECTORY_DOWNLOADS
 import android.os.Environment.getExternalStoragePublicDirectory
 import zlc.season.rxdownload3.database.DbActor
@@ -21,7 +20,7 @@ object DownloadConfig {
     internal val TMP_DIR_SUFFIX = ".TMP"
     internal val TMP_FILE_SUFFIX = ".tmp"
 
-    internal val RANGE_DOWNLOAD_SIZE: Long = 4 * 1024 * 1024  //4M
+    internal var rangeDownloadSize: Long = 4 * 1024 * 1024  //4M
 
     internal var maxMission = 3
     internal var maxRange = Runtime.getRuntime().availableProcessors() + 1
@@ -55,6 +54,7 @@ object DownloadConfig {
         this.fps = builder.fps
         this.maxMission = builder.maxMission
         this.maxRange = builder.maxRange
+        this.rangeDownloadSize = builder.rangeDownloadSize
         this.defaultSavePath = builder.defaultSavePath
 
         this.autoStart = builder.autoStart
@@ -85,6 +85,7 @@ object DownloadConfig {
     class Builder private constructor(val context: Context) {
         internal var maxMission = 3
         internal var maxRange = Runtime.getRuntime().availableProcessors() + 1
+        internal var rangeDownloadSize: Long = 4 * 1024 * 1024  //4M
 
         internal var debug = true
 

--- a/rxdownload3/src/main/java/zlc/season/rxdownload3/core/RangeTmpFile.kt
+++ b/rxdownload3/src/main/java/zlc/season/rxdownload3/core/RangeTmpFile.kt
@@ -5,9 +5,9 @@ import okio.BufferedSink
 import okio.BufferedSource
 import okio.ByteString.decodeHex
 import okio.Okio
-import zlc.season.rxdownload3.core.DownloadConfig.RANGE_DOWNLOAD_SIZE
 import zlc.season.rxdownload3.core.DownloadConfig.TMP_DIR_SUFFIX
 import zlc.season.rxdownload3.core.DownloadConfig.TMP_FILE_SUFFIX
+import zlc.season.rxdownload3.core.DownloadConfig.rangeDownloadSize
 import zlc.season.rxdownload3.core.RangeTmpFile.Segment.Companion.SEGMENT_SIZE
 import java.io.File
 import java.io.File.separator
@@ -136,12 +136,12 @@ class RangeTmpFile(val mission: RealMission) {
                 val end = if (i == totalSegments - 1) {
                     mission.totalSize - 1
                 } else {
-                    start + RANGE_DOWNLOAD_SIZE - 1
+                    start + rangeDownloadSize - 1
                 }
 
                 segments.add(Segment(i, start, start, end).write(sink))
 
-                start += RANGE_DOWNLOAD_SIZE
+                start += rangeDownloadSize
             }
         }
 
@@ -177,11 +177,11 @@ class RangeTmpFile(val mission: RealMission) {
         }
 
         private fun calculateSegments(): Long {
-            val remainder = mission.totalSize % RANGE_DOWNLOAD_SIZE
+            val remainder = mission.totalSize % rangeDownloadSize
             return if (remainder == 0L) {
-                mission.totalSize / RANGE_DOWNLOAD_SIZE
+                mission.totalSize / rangeDownloadSize
             } else {
-                mission.totalSize / RANGE_DOWNLOAD_SIZE + 1
+                mission.totalSize / rangeDownloadSize + 1
             }
         }
     }


### PR DESCRIPTION
With this PR, Range Download Size can be configured with `DownloadConfig` Builder. This closes https://github.com/ssseasonnn/RxDownload/issues/174