### PR TITLE
feat :call mmission state with rx(onComplete....)

### DIFF
--- a/rxdownload3/src/main/java/zlc/season/rxdownload3/core/RealMission.kt
+++ b/rxdownload3/src/main/java/zlc/season/rxdownload3/core/RealMission.kt
@@ -150,10 +150,12 @@ class RealMission(val actual: Mission, private val semaphore: Semaphore,
                 .doOnError {
                     loge("Mission error! ${it.message}", it)
                     emitStatusWithNotification(Failed(status, it))
+                    processor.onError(it)
                 }
                 .doOnComplete {
                     logd("Mission complete!")
                     emitStatusWithNotification(Succeed(status))
+                    processor.onComplete()
                 }
                 .doOnCancel {
                     logd("Mission cancel!")


### PR DESCRIPTION
目前的Flowable在执行完成和出错的时候没有调onComplete和onErr,对全流程rx操作不是很友好,所以改了一下